### PR TITLE
Adds api endpoint for accessing courses with top enrollments/compleyions

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -186,6 +186,24 @@ class CourseDailyMetricsSerializer(serializers.ModelSerializer):
         exclude = ()
 
 
+class CourseTopStatsSerializer(serializers.ModelSerializer):
+    """
+    Serializer to return top course stats for summary page.
+    """
+    course_name = serializers.SerializerMethodField()
+
+    def get_course_name(self, obj):
+        """
+        Get course name from "CourseOverview" model.
+        """
+        course_overview = CourseOverview.objects.filter(id=as_course_key(obj.course_id)).first()
+        return course_overview.display_name if course_overview else ''
+
+    class Meta:
+        model = CourseDailyMetrics
+        fields = ('course_name', 'enrollment_count', 'num_learners_completed')
+
+
 class SiteDailyMetricsSerializer(serializers.ModelSerializer):
     """Proviedes summary data about the LMS site
     """

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -201,7 +201,7 @@ class CourseTopStatsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CourseDailyMetrics
-        fields = ('course_name', 'enrollment_count', 'num_learners_completed')
+        fields = ('course_name', 'course_id', 'enrollment_count', 'num_learners_completed')
 
 
 class SiteDailyMetricsSerializer(serializers.ModelSerializer):

--- a/figures/urls.py
+++ b/figures/urls.py
@@ -78,6 +78,11 @@ router.register(
     base_name='courses-general')
 
 router.register(
+    r'courses/stats',
+    views.CourseTopStatsViewSet,
+    base_name='courses-top-stats')
+
+router.register(
     r'courses/detail',
     views.CourseDetailsViewSet,
     base_name='courses-detail')

--- a/figures/views.py
+++ b/figures/views.py
@@ -328,9 +328,6 @@ class CourseTopStatsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     Viewset to get top courses by enrollments/completions.
     """
     model = CourseDailyMetrics
-
-    # The "kilo paginator"  is a tempoarary hack to return all course to not
-    # have to change the front end until Figures "Level 2"
     pagination_class = FiguresKiloPagination
     serializer_class = CourseTopStatsSerializer
 
@@ -345,7 +342,7 @@ class CourseTopStatsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
             order_by_sign = '' if order_by_sign == 'asc' else '-'
             queryset = queryset.order_by(order_by_sign + order_by_name)
 
-        return queryset[:10]
+        return queryset
 
 
 class CourseDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -29,6 +29,7 @@ from figures.serializers import (
     CourseEnrollmentSerializer,
     CourseMauMetricsSerializer,
     CourseMauLiveMetricsSerializer,
+    CourseTopStatsSerializer,
     GeneralCourseDataSerializer,
     GeneralUserDataSerializer,
     LearnerCourseDetailsSerializer,
@@ -256,6 +257,26 @@ class TestCourseDailyMetricsSerializer(object):
         serializer = CourseDailyMetricsSerializer(instance=obj)
         with pytest.raises(ValidationError):
             data = serializer.data
+
+
+@pytest.mark.django_db
+class TestCourseTopStatsSerializer(object):
+    """
+    Tests the CourseTopStatsSerializer serializer class.
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.model = CourseDailyMetrics
+        self.metrics = CourseDailyMetricsFactory()
+        self.serializer = CourseTopStatsSerializer(instance=self.metrics)
+
+    def test_has_fields(self):
+        """
+        Verify the serialized data has the same keys and values as the model
+        """
+        data = self.serializer.data
+        assert data['enrollment_count'] == self.metrics.enrollment_count
+        assert data['num_learners_completed'] == self.metrics.num_learners_completed
 
 
 @pytest.mark.django_db

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -275,6 +275,7 @@ class TestCourseTopStatsSerializer(object):
         Verify the serialized data has the same keys and values as the model
         """
         data = self.serializer.data
+        assert data['course_id'] == self.metrics.course_id
         assert data['enrollment_count'] == self.metrics.enrollment_count
         assert data['num_learners_completed'] == self.metrics.num_learners_completed
 

--- a/tests/views/test_course_top_stats_metrics_view.py
+++ b/tests/views/test_course_top_stats_metrics_view.py
@@ -17,7 +17,7 @@ from openedx.features.edly.tests.factories import (
     EdlySubOrganizationFactory,
 )
 
-import figures.helpers
+from figures.helpers import as_course_key
 from figures.helpers import is_multisite
 from figures.views import CourseTopStatsViewSet
 
@@ -83,6 +83,7 @@ class TestCourseTopStatsViewSet(object):
         assert len(response.data['results']) == len(self.course_overviews)
 
         for rec in response.data['results']:
+            assert CourseOverview.objects.get(id=as_course_key(rec['course_id']))
             assert CourseOverview.objects.get(display_name=rec['course_name'])
         assert response.data['results'][0]['enrollment_count'] >= response.data['results'][1]['enrollment_count']
 

--- a/tests/views/test_course_top_stats_metrics_view.py
+++ b/tests/views/test_course_top_stats_metrics_view.py
@@ -1,0 +1,106 @@
+
+import mock
+import pytest
+
+from rest_framework.test import (
+    APIRequestFactory,
+    force_authenticate,
+)
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from openedx.core.djangoapps.content.course_overviews.models import (
+    CourseOverview,
+)
+from openedx.features.edly.tests.factories import (
+    EdlySubOrganizationFactory,
+)
+
+import figures.helpers
+from figures.helpers import is_multisite
+from figures.views import CourseTopStatsViewSet
+
+from tests.factories import (
+    CourseDailyMetricsFactory,
+    CourseOverviewFactory,
+    OrganizationFactory,
+    OrganizationCourseFactory,
+    SiteFactory,
+)
+from tests.views.helpers import create_test_users
+
+
+@pytest.mark.django_db
+class TestCourseTopStatsViewSet(object):
+    """
+    Tests the CourseTopStatsViewSet class
+    """
+
+    request_path_top_enrollments = 'api/courses/stats/?order_by=enrollment_count,desc'
+    request_path_top_completions = 'api/courses/stats/?order_by=num_learners_completed,desc'
+    view_class = CourseTopStatsViewSet
+
+    def setup(self):
+        self.callers = create_test_users()
+        self.course_overviews = [CourseOverviewFactory() for i in range(4)]
+        self.expected_result_keys = [
+            'course_name', 'enrollment_count', 'num_of_learners_completed'
+        ]
+        if is_multisite():
+            self.site = SiteFactory(domain='foo.test')
+            self.organization = OrganizationFactory()
+            self.edly_sub_organization = EdlySubOrganizationFactory(
+                lms_site=self.site,
+                edx_organization=self.organization
+            )
+            for course_overview in self.course_overviews:
+                OrganizationCourseFactory(
+                    organization=self.organization,
+                    course_id=str(course_overview.id)
+                )
+                CourseDailyMetricsFactory(
+                    course_id=str(course_overview.id),
+                    site=self.site
+                )
+
+    @property
+    def staff_user(self):
+        return get_user_model().objects.get(username='staff_user')
+
+    def test_get_list_top_enrollments(self):
+        """
+        Tests retrieving a list of courses with maximum number of enrollments.
+        """
+        request = RequestFactory(SERVER_NAME=self.site.domain).get(self.request_path_top_enrollments)
+        force_authenticate(request, user=self.staff_user)
+        view = self.view_class.as_view({'get': 'list'})
+        response = view(request)
+
+        assert response.status_code == 200
+        assert set(response.data.keys()) == set(
+            ['count', 'next', 'previous', 'results', ])
+        assert len(response.data['results']) == len(self.course_overviews)
+
+        for rec in response.data['results']:
+            assert CourseOverview.objects.get(display_name=rec['course_name'])
+        assert response.data['results'][0]['enrollment_count'] >= response.data['results'][1]['enrollment_count']
+
+
+    def test_get_list_top_completions(self):
+        """
+        Tests retrieving a list of courses with maximum number of completions.
+        """
+        request = RequestFactory(SERVER_NAME=self.site.domain).get(self.request_path_top_completions)
+        force_authenticate(request, user=self.staff_user)
+        view = self.view_class.as_view({'get': 'list'})
+        response = view(request)
+
+        assert response.status_code == 200
+        assert set(response.data.keys()) == set(
+            ['count', 'next', 'previous', 'results', ])
+        assert len(response.data['results']) == len(self.course_overviews)
+
+        for rec in response.data['results']:
+            assert CourseOverview.objects.get(display_name=rec['course_name'])
+        assert response.data['results'][0]['num_learners_completed'] >= response.data['results'][1]['num_learners_completed']


### PR DESCRIPTION
**Description:**
This PR adds an API endpoint (http://blue.courses.edx.devstack.lms:18000/figures/api/courses/stats/?order_by=num_learners_completed,desc) or (http://blue.courses.edx.devstack.lms:18000/figures/api/courses/stats/?order_by=enrollment_count,desc) for accessing courses with maximum enrollments/completions.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1766