### PR TITLE
Added User's Last Active Information in Users Detail API

### DIFF
--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -686,6 +686,7 @@ class LearnerDetailsSerializer(serializers.ModelSerializer):
       "level_of_education": "b",
       "gender": "m",
       "date_joined": "2018-05-06T14:01:58Z",
+      "last_login": "2018-05-06T14:01:58Z",
       "bio": null,
       "profile_image": {
             "image_url_full": "http://localhost:8000/static/images/profiles/default_500.png",
@@ -746,7 +747,7 @@ class LearnerDetailsSerializer(serializers.ModelSerializer):
         editable = False
         fields = (
             'id', 'username', 'name', 'email', 'country', 'is_active',
-            'year_of_birth', 'level_of_education', 'gender', 'date_joined',
+            'year_of_birth', 'level_of_education', 'gender', 'date_joined', 'last_login',
             'bio', 'courses', 'language_proficiencies', 'profile_image',
             )
         read_only_fields = fields

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -169,10 +169,17 @@ def get_courses_for_site(site):
 def get_user_ids_for_site(site):
     if figures.helpers.is_multisite():
         edx_organizations = organizations.models.Organization.objects.filter(edlysuborganization__lms_site=site)
-        edly_user_profiles = EdlyUserProfile.objects.filter(edly_sub_organizations__edx_organization__in=edx_organizations)
+        edly_user_profiles = EdlyUserProfile.objects.filter(
+            edly_sub_organizations__edx_organization__in=edx_organizations
+        ).exclude(
+            user__groups__name=settings.ADMIN_CONFIGURATION_USERS_GROUP
+        )
+
         user_ids = edly_user_profiles.values_list('user', flat=True)
     else:
-        user_ids = get_user_model().objects.all().values_list('id', flat=True)
+        user_ids = get_user_model().objects.all().exclude(
+            user__groups__name=settings.ADMIN_CONFIGURATION_USERS_GROUP
+        ).values_list('id', flat=True)
     return user_ids
 
 

--- a/figures/views.py
+++ b/figures/views.py
@@ -267,7 +267,7 @@ class GeneralSiteMetricsView(CommonAuthMixin, APIView):
     and list the most recent data for all sites (or filtered sites)
     """
 
-    pagination_class = FiguresLimitOffsetPagination
+    pagination_class = FiguresTopStatsPagination
 
     @property
     def metrics_method(self):
@@ -410,6 +410,7 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = LearnerDetailsSerializer
     filter_backends = (DjangoFilterBackend, )
     filter_class = UserFilterSet
+    search_fields = ['profile__name', 'username', 'email']
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)

--- a/tests/views/test_learner_details_view.py
+++ b/tests/views/test_learner_details_view.py
@@ -286,7 +286,7 @@ class TestLearnerDetailsViewSetMultisite(BaseViewTest):
 
         self.expected_result_keys = [
             'id', 'username', 'name', 'email', 'country', 'is_active',
-            'year_of_birth', 'level_of_education', 'gender', 'date_joined',
+            'year_of_birth', 'level_of_education', 'gender', 'date_joined', 'last_login',
             'bio', 'courses', 'language_proficiencies', 'profile_image'
         ]
 


### PR DESCRIPTION
**Description:** This PR adds implementation to add user's last active information in Users Detail API

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1865


**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.