### PR TITLE
Add Missing Search Option in Course Enrollments API

### DIFF
--- a/figures/views.py
+++ b/figures/views.py
@@ -210,6 +210,7 @@ class CourseEnrollmentViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = CourseEnrollmentSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter,)
     filter_class = CourseEnrollmentFilter
+    search_fields = ['user__profile__name', 'user__username', 'user__email']
 
     def paginate_queryset(self, queryset, view=None):
         """


### PR DESCRIPTION
**Description:** This PR adds missing search fields option in Course Enrollments API, which was removed mistakenly from reference PR.

**Reference PR:** https://github.com/edly-io/figures/pull/14

