### PR TITLE
Change Pagination of Courses API and Rename Pagination Class

### DIFF
--- a/figures/pagination.py
+++ b/figures/pagination.py
@@ -6,7 +6,7 @@ from rest_framework.pagination import LimitOffsetPagination, PageNumberPaginatio
 from rest_framework.response import Response
 
 
-class FiguresTopStatsPagination(PageNumberPagination):
+class FiguresPageLevelPagination(PageNumberPagination):
     """
     Custom Figures paginator to make the number of records returned consistent
     """


### PR DESCRIPTION
**Description:**  This PR updates pagination of Courses API and rename pagination class `FiguresTopStatsPagination` to `FiguresPageLevelPagination`

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.