### PR TITLE
Missing End Date Active Course Count Issue Fixed

### DIFF
--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -458,6 +458,9 @@ def get_total_active_courses_for_time_period(site, start_date, end_date):
                 ) |
                 Q(
                     Q(end__gt=prev_day(start_date)) & Q(end__lt=next_day(end_date))
+                ) |
+                Q(
+                    Q(start__lt=prev_day(start_date)) & Q(end__isnull=True)
                 )
             ).values(
                 'id'


### PR DESCRIPTION
**Description:**  This PR fixes Active courses stat is showing incorrect values due to missing end date in the course.

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.