### PR TITLE
Fix figures ability to update LearnerGradeMetrics records

### DIFF
--- a/figures/compat.py
+++ b/figures/compat.py
@@ -47,7 +47,7 @@ def course_grade(learner, course):
     else:  # Assume Hawthorn or greater
         course_grade = CourseGradeFactory().read(learner, course)
 
-    persistent_course_grade = PersistentCourseGrade.objects.filter(user_id=learner.id, course_id=course.id).first()
+    persistent_course_grade = PersistentCourseGrade.objects.filter(user_id=learner.id, course_id=course.id).order_by('-modified').first()
     course_grade.passed_timestamp = persistent_course_grade.passed_timestamp if persistent_course_grade else None
     return course_grade
 

--- a/figures/pipeline/enrollment_metrics.py
+++ b/figures/pipeline/enrollment_metrics.py
@@ -261,19 +261,22 @@ def _enrollment_metrics_needs_update(most_recent_lcgm, most_recent_sm):
 def _add_enrollment_metrics_record(site, course_enrollment, progress_data, date_for):
     """Convenience function to save progress metrics to Figures
     """
-    return LearnerCourseGradeMetrics.objects.create(
-        site=site,
+    enrollment_metrics = LearnerCourseGradeMetrics.objects.update_or_create(
+        defaults={
+            'site': site,
+            'points_possible': progress_data['points_possible'],
+            'points_earned': progress_data['points_earned'],
+            'sections_worked': progress_data['sections_worked'],
+            'sections_possible': progress_data['count'],
+            'percent_grade': progress_data.get('grade', {}).get('percent_grade', 0.0),
+            'letter_grade': progress_data.get('grade', {}).get('letter_grade', ''),
+            'passed_timestamp': progress_data.get('passed_timestamp', None),
+        },
         user=course_enrollment.user,
         course_id=str(course_enrollment.course_id),
         date_for=date_for,
-        points_possible=progress_data['points_possible'],
-        points_earned=progress_data['points_earned'],
-        sections_worked=progress_data['sections_worked'],
-        sections_possible=progress_data['count'],
-        percent_grade=progress_data.get('grade', {}).get('percent_grade', 0.0),
-        letter_grade=progress_data.get('grade', {}).get('letter_grade', ''),
-        passed_timestamp=progress_data.get('passed_timestamp', None),
-        )
+    )
+    return enrollment_metrics[0]
 
 
 def _collect_progress_data(student_module):


### PR DESCRIPTION
**Description:** Till now figures was unable to pull updated data from PersistentCourseGrade because it wants to create a new object every time but the with new object every time we get integrity error for data update. Either we can remove that constraint or we can allow figures to update data for the same user, course, and date_for. The reason for allowing figures to update data is that we can expect the user to reattempt the course on the same day.

**Note: To make this work perfectly for our existing LearnerCourseGradeMetrics we would have to drop all data from the table to recompute it as there's a high possibility we might still not update data due to integrity error.**

**Jira:**https://edlyio.atlassian.net/browse/EDLY-1893
**Related PRs:**

1. https://github.com/edly-io/figures/pull/24
2. https://github.com/edly-io/figures/pull/23