### PR TITLE
Reschedule Populate Daily Metrics Cron Job

### DIFF
--- a/figures/settings/lms_production.py
+++ b/figures/settings/lms_production.py
@@ -35,8 +35,8 @@ def update_celerybeat_schedule(celerybeat_schedule_settings, figures_env_tokens)
         celerybeat_schedule_settings['figures-populate-daily-metrics'] = {
             'task': 'figures.tasks.populate_daily_metrics',
             'schedule': crontab(
-                hour=figures_env_tokens.get('DAILY_METRICS_IMPORT_HOUR', 2),
-                minute=figures_env_tokens.get('DAILY_METRICS_IMPORT_MINUTE', 0),
+                hour=figures_env_tokens.get('DAILY_METRICS_IMPORT_HOUR', 0),
+                minute=figures_env_tokens.get('DAILY_METRICS_IMPORT_MINUTE', 30),
                 ),
             }
 


### PR DESCRIPTION
**Description:** This PR updates `populate daily metrics` cron job to run every thirty minutes.


**Merge checklist:**

- [ ] All reviewers approved
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Note:** Please add screenshots for any viewable change.