### PR TITLE
Fix Course completion > Data mismatch on quick stat and Top course by completion  

### DIFF
--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -208,7 +208,7 @@ def get_num_learners_completed(site, course_id, date_for):
         course_id=as_course_key(course_id),
         user_id__in=users_ids,
         passed_timestamp__isnull=False,
-        passed_timestamp__lte=as_datetime(date_for),
+        passed_timestamp__lte=as_datetime(date_for + datetime.timedelta(days=1)),
     )
 
     return grades.count()


### PR DESCRIPTION
**Description:** Get persistent grade for 1 day ahead as converting date to datetime will return the start of that current day. Completion can happen anytime on that day.

**Jira:** https://edlyio.atlassian.net/browse/EDLY-2042