### PR TITLE
Fix figures site test failing EDLY-2380

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -81,7 +81,9 @@ def make_user(**kwargs):
 @pytest.mark.django_db
 class CourseEnrollmentFilterTest(TestCase):
     def setUp(self):
-        self.users = [make_user(**data) for data in USER_DATA]
+        self.users = [
+            UserFactory(username=data['username'], profile__name=data['fullname']) for data in USER_DATA
+        ]
         self.course_overview = CourseOverviewFactory()
         self.course_enrollments = [
             CourseEnrollmentFactory(course_id=self.course_overview.id, user=self.users[i]) for i in range(4)


### PR DESCRIPTION
**Description:** Fix figures site test `get_course_enrollments_for_site` test  in class `TestHandlersForMultisiteMode`

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2380

**Visible Changes:**
`Terminal Output`
<img width="1407" alt="Screenshot 2020-12-28 at 11 40 53 AM" src="https://user-images.githubusercontent.com/68893403/103194609-fcccb080-4901-11eb-8d68-fd75193e968b.png">
