### PR TITLE
EDLY-2765 Used today as metrics date instead of yesterday

### DIFF
--- a/figures/pipeline/helpers.py
+++ b/figures/pipeline/helpers.py
@@ -50,6 +50,6 @@ def pipeline_date_for_rule(date_for):
             msg = 'Attempted pipeline call with future date: "{date_for}"'
             raise DateForCannotBeFutureError(msg.format(date_for=date_for))
         elif date_for == today:
-            return prev_day(today)
+            return today
 
     return date_for

--- a/tests/pipeline/test_helpers.py
+++ b/tests/pipeline/test_helpers.py
@@ -41,14 +41,12 @@ def run_pipeline_date_for_rule_asserts(arg_datetime, expected_date):
     assert pipeline_date_for_rule(str(arg_datetime.date())) == expected_date
 
 
-@pytest.mark.parametrize('day_from_now', [-1, 0])
-def test_pipeline_date_for_rule_get_yesterday(day_from_now):
-    """Ensure function under test returns yesterday as a datetime.date instance
+def test_pipeline_date_for_rule_get_today():
+    """Ensure function under test returns today as a datetime.date instance
     """
     now = datetime.utcnow().replace(tzinfo=utc)
-    arg_datetime = now + timedelta(days=day_from_now)
-    expected_date = (now - timedelta(days=1)).date()
-    run_pipeline_date_for_rule_asserts(arg_datetime, expected_date)
+    expected_date = now.date()
+    run_pipeline_date_for_rule_asserts(now, expected_date)
 
 
 @pytest.mark.parametrize('days_in_past', [1, 2, 3, 10, 999])


### PR DESCRIPTION
**Description:** This pr converts date_for daily site metrics to actual today instead of yesterday as we've delay of only 4 hours in Edly Insights on the other hand appsembler might have a delay of 1 day.

**Jira:** https://edlyio.atlassian.net/browse/EDLY-2765