### PR TITLE
Fix active course stats issue - EDLY-4230

### DIFF
--- a/figures/metrics.py
+++ b/figures/metrics.py
@@ -29,7 +29,7 @@ import math
 from django.contrib.auth import get_user_model
 from django.db.models import Avg, Max, Sum, Q
 
-import organizations
+from openedx.features.edly.models import EdlySubOrganization
 
 from figures.compat import (
     GeneratedCertificate,
@@ -595,9 +595,9 @@ def get_total_active_courses_for_time_period(site, start_date, end_date):
     """
 
     def calc_from_courses_overview():
-        edx_organizations = organizations.models.Organization.objects.filter(
-            edlysuborganization__lms_site=site
-        ).using(read_replica_or_default()).values_list('short_name', flat=True)
+        edx_organizations = EdlySubOrganization.objects.filter(
+            lms_site=site,
+        ).using(read_replica_or_default()).first().get_edx_organizations
 
         if edx_organizations:
             return CourseOverview.objects.filter(

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -301,6 +301,7 @@ class TestSiteMetricsGettersStandalone(object):
         self.site = Site.objects.first()
         self.data_start_date = DEFAULT_START_DATE
         self.data_end_date = DEFAULT_END_DATE
+        self.edly_sub_org = EdlySubOrganizationFactory(lms_site=self.site)
         self.features = {'FIGURES_IS_MULTISITE': False}
         self.site_daily_metrics = create_site_daily_metrics_data(
             site=self.site,


### PR DESCRIPTION
**Description:** This PR fixes the issue for monthly active course stats issue not appearing due to deprecated `edx_organization` link with `EdlySubOrganization`. 

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-4230