### PR TITLE
Remore farthest block information from csv reports - EDLY-4790

### DIFF
--- a/figures/edly_views/edly_reports.py
+++ b/figures/edly_views/edly_reports.py
@@ -349,21 +349,10 @@ class InsightCoursesCSV(APIView):
         course_enrollments = InsightCoursesCSV._get_course_enrollments(fake_req)
         course_enrollments = InsightCoursesCSV._get_serialized_enrollments(course_enrollments)
 
-        learners = get_user_model().objects.filter(
-            username__in=[l['user']['username'] for l in course_enrollments]
-        )
-        all_blocks = dict()
-        for learner in learners:
-            fake_req.user = learner
-            all_blocks[learner.username] = get_course_outline_block_tree(
-                fake_req, six.text_type(course_id.replace(' ', '+')),
-                learner, allow_start_dates_in_future=True
-            )
-
         course_maus = InsightCoursesCSV._get_courses_maus(site, course_id)
         figures.helpers.send_insights_course_detail_report(
             course_overview, course_details, course_maus, course_enrollments,
-            all_blocks, user_email, username, 'Course Detail Report', site_config
+            user_email, username, 'Course Detail Report', site_config
         )
 
     def get(self, request):

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -805,7 +805,7 @@ def send_learner_report(learners_data, all_blocks, recipient_email, username, re
 
 def send_insights_course_detail_report(
     course_overview, course_details, course_maus, learners,
-    all_blocks, recipient_email, username, report_type, site_configs
+    recipient_email, username, report_type, site_configs
 ):
     csv_file = StringIO()
     csv_report_writer = csv.writer(csv_file)
@@ -849,9 +849,6 @@ def send_insights_course_detail_report(
         'Email',
         'Enrollment Mode',
         'Enrollment Date',
-        'Farthest Completed Block (Section)',
-        'Farthest Completed Block (Subsection)',
-        'Farthest Completed Block (Unit)',
         'Completion Date',
         'Grade',
         'Graded Course Progress',
@@ -867,7 +864,6 @@ def send_insights_course_detail_report(
             learner['user']['email'],
             learner.get('mode') or 'N/A',
             learner['courses'][0]['date_enrolled'],
-            *get_farthest_complete_block(all_blocks[learner['user']['username']]),
             learner['courses'][0]['progress_data']['passed_timestamp'],
             learner['courses'][0]['progress_data']['letter_grade'],
             '{}%'.format(learner['courses'][0]['progress_data']['course_progress']),


### PR DESCRIPTION
**Description: ** This PR removes the farthest xblock changes for now as celery task was getting stuck on large datasets.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-4790