### PR TITLE
Adding Video-Xblock progress and completion in Video Progress

### DIFF
--- a/mocks/juniper/edly_panel_app/api/v1/constants.py
+++ b/mocks/juniper/edly_panel_app/api/v1/constants.py
@@ -5,7 +5,8 @@ from django.utils.translation import ugettext as _
 
 
 BLOCK_TYPES_TO_FILTER = ['course', 'chapter', 'sequential', 'vertical', 'discussion', 'openassessment']
-CORE_BLOCK_TYPES = ['html', 'video', 'problem']
+CORE_BLOCK_TYPES = ['html', 'video', 'problem', 'video_xblock']
+VIDEO_BLOCK_TYPES = ['video', 'video_xblock']
 
 EDLY_PANEL_WORKER_USER = 'edly_panel_worker'
 

--- a/mocks/juniper/edly_panel_app/api/v1/helpers.py
+++ b/mocks/juniper/edly_panel_app/api/v1/helpers.py
@@ -16,7 +16,8 @@ from django.template.loader import get_template
 from edly_panel_app.api.v1.constants import (
     ERROR_MESSAGES,
     BLOCK_TYPES_TO_FILTER,
-    CORE_BLOCK_TYPES
+    CORE_BLOCK_TYPES,
+    VIDEO_BLOCK_TYPES,
 )
 from lms.djangoapps.course_api.blocks.serializers import BlockDictSerializer
 from lms.djangoapps.course_api.blocks.transformers.blocks_api import BlocksAPITransformer


### PR DESCRIPTION
**Description:**
The progress for Video Xblock was tracked in other currently. It has been moved to Video section in the Progress tab.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-4931