### PR TITLE
Add  permission for insight panel

### DIFF
--- a/figures/edly_views/edly_reports.py
+++ b/figures/edly_views/edly_reports.py
@@ -8,7 +8,6 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.http.request import HttpRequest
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
-from edly_panel_app.api.v1.permissions import AdminAccessEdlyPanel
 from edly_panel_app.api.v1.views import (
     GetMonthlyActiveUsers, GetMonthlyCourseCompletions
 )
@@ -32,6 +31,7 @@ from figures.models import (
     CourseDailyMetrics, LearnerCourseGradeMetrics,
     SiteDailyMetrics
 )
+from figures.permissions import CanAccessEdlyInsights
 import figures.sites
 from figures.serializers import (
     CourseDetailsSerializer,
@@ -49,7 +49,7 @@ class InsightSummaryCSV(APIView):
     """
 
     authentication_classes = (OAuth2Authentication, SessionAuthentication,)
-    permission_classes = [IsAuthenticated, AdminAccessEdlyPanel]
+    permission_classes = [IsAuthenticated, CanAccessEdlyInsights]
 
     @staticmethod
     def _get_figures_general_site_metrics(site, query_params):
@@ -162,7 +162,7 @@ class InsightLearnersCSV(APIView):
     """
 
     authentication_classes = (OAuth2Authentication, SessionAuthentication,)
-    permission_classes = [IsAuthenticated, AdminAccessEdlyPanel]
+    permission_classes = [IsAuthenticated, CanAccessEdlyInsights]
 
     @staticmethod
     def _get_site_monthly_metrics(site):
@@ -302,7 +302,7 @@ class InsightCoursesCSV(APIView):
     """
 
     authentication_classes = (OAuth2Authentication, SessionAuthentication,)
-    permission_classes = [IsAuthenticated, AdminAccessEdlyPanel]
+    permission_classes = [IsAuthenticated, CanAccessEdlyInsights]
 
     @staticmethod
     def _get_course_enrollments(request):

--- a/figures/permissions.py
+++ b/figures/permissions.py
@@ -13,8 +13,10 @@ try:
 except ImportError:
     pass
 
-from openedx.features.edly.utils import edly_panel_user_has_edly_org_access
-
+from openedx.features.edly.utils import (
+    edly_panel_user_has_edly_org_access, get_edly_sub_org_from_request,
+    user_has_edly_organization_access
+)
 import figures.helpers
 import figures.sites
 
@@ -95,3 +97,18 @@ class IsStaffUserOnDefaultSite(BasePermission):
 
     def has_permission(self, request, view):
         return is_staff_user_on_default_site(request) or has_insights_access(request)
+
+
+class CanAccessEdlyInsights(BasePermission):
+    """
+    Allow access to edly panel admin or insights users.
+    """
+
+    def has_permission(self, request, view):
+        sub_org = get_edly_sub_org_from_request(request)
+        is_edly_access_user = request.user.edly_multisite_user.filter(
+            sub_org=sub_org,
+            groups__name__in=[settings.EDLY_INSIGHTS_GROUP, settings.EDLY_PANEL_ADMIN_USERS_GROUP]
+        ).exists()
+        has_edly_user_access = user_has_edly_organization_access(request) and (is_edly_access_user)
+        return has_edly_user_access


### PR DESCRIPTION
##Description
When generating email reports an Insight Viewer user does not get the report in the inbox, the issue arises due to not having permission for the Insights user to generate CSV insights data.

##Jira
https://edlyio.atlassian.net/browse/EDLY-5971