### PR TITLE
Add last login to ordering in user detail api

### DIFF
--- a/figures/views.py
+++ b/figures/views.py
@@ -567,7 +567,7 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = LearnerDetailsSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter, OrderingFilter, )
     search_fields = ['profile__name', 'username', 'email']
-    ordering_fields = ['profile__name', 'username', 'email', 'is_active', 'date_joined']
+    ordering_fields = ['profile__name', 'username', 'email', 'is_active', 'date_joined', 'last_login', ]
     filter_class = UserFilterSet
 
     def paginate_queryset(self, queryset, view=None):


### PR DESCRIPTION
**Description:** This PR adds `last_login` to ordering backend list for `user/detail` view.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-6021