### PR TITLE
Missing SSO ID to course report EDLY-6824

### DIFF
--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -928,7 +928,7 @@ def send_insights_course_detail_report(
             learner['user']['fullname'],
             learner['user']['username'],
             learner['user']['email'],
-            learner['user'].get('sso_id'),
+            learner['courses'][0]['sso_id'] or 'N/A',
             learner.get('mode') or 'N/A',
             learner['courses'][0]['date_enrolled'],
             learner['courses'][0]['progress_data']['passed_timestamp'],


### PR DESCRIPTION
### Description:
SSO ID missing from Course Detail Reports

### Jira:
https://edlyio.atlassian.net/browse/EDLY-6824

<img width="795" alt="Screenshot 2024-05-29 at 11 01 51 PM" src="https://github.com/edly-io/figures/assets/129956601/43c5b7c7-2a54-4398-a997-f372657fb0d7">
