### PR TITLE
Added management command to delete old pipeline errors

### DIFF
--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -33,9 +33,10 @@ class Command(BaseCommand):
             old_records = PipelineError.objects.filter(created__lt=cutoff_date)[:batch_size]
             if not old_records.exists():
                 break
-            deleted, _ = old_records.delete()
-            total_deleted += deleted
-            print(f"Deleted {deleted} records in this batch. Total deleted: {total_deleted}.")
+            ids_to_delete = list(old_records.values_list('id', flat=True))
+            PipelineError.objects.filter(id__in=ids_to_delete).delete()
+            total_deleted += len(ids_to_delete)
+            print(f"Deleted {len(ids_to_delete)} records in this batch. Total deleted: {total_deleted}.")
 
         print(f"Deletion complete. Total {total_deleted} PipelineError records older than {days} days deleted.")
         print('Done.')

--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
         print(f"Deleting PipelineError records older than {days} days in batches...")
 
-        batch_size = 1000  # Adjust batch size as needed for optimal performance
+        batch_size = 1000
         total_deleted = 0
 
         while True:

--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -26,15 +26,17 @@ class Command(BaseCommand):
 
         print(f"Deleting PipelineError records older than {days} days in batches...")
 
-        batch_size = 1000
+        batch_size = 1000  # Adjust batch size as needed for optimal performance
         total_deleted = 0
+
         while True:
             old_records = PipelineError.objects.filter(created__lt=cutoff_date)[:batch_size]
-            if not old_records:
+            if not old_records.exists():
                 break
-            deleted_count = old_records.delete()[0]
-            total_deleted += deleted_count
-            print(f"Deleted {deleted_count} records in this batch. Total deleted: {total_deleted}.")
+            ids_to_delete = list(old_records.values_list('id', flat=True))
+            PipelineError.objects.filter(id__in=ids_to_delete).delete()
+            total_deleted += len(ids_to_delete)
+            print(f"Deleted {len(ids_to_delete)} records in this batch. Total deleted: {total_deleted}.")
 
         print(f"Deletion complete. Total {total_deleted} PipelineError records older than {days} days deleted.")
         print('Done.')

--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now, timedelta
+from figures.models import PipelineError
+
+class Command(BaseCommand):
+    '''Delete PipelineError records older than a specified number of days (default is 15 days).'''
+    help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        '''Add command arguments.'''
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=15,
+            help='Number of days to retain PipelineError records. Defaults to 15.',
+        )
+
+    def handle(self, *args, **options):
+        '''Handle the deletion process.'''
+        days = options['days']
+        cutoff_date = now() - timedelta(days=days)
+
+        print(f"Deleting PipelineError records older than {days} days...")
+
+        deleted_count, _ = PipelineError.objects.filter(created__lt=cutoff_date).delete()
+
+        print(f"Deleted {deleted_count} PipelineError records older than {days} days.")
+        print('Done.')

--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -33,10 +33,9 @@ class Command(BaseCommand):
             old_records = PipelineError.objects.filter(created__lt=cutoff_date)[:batch_size]
             if not old_records.exists():
                 break
-            ids_to_delete = list(old_records.values_list('id', flat=True))
-            PipelineError.objects.filter(id__in=ids_to_delete).delete()
-            total_deleted += len(ids_to_delete)
-            print(f"Deleted {len(ids_to_delete)} records in this batch. Total deleted: {total_deleted}.")
+            deleted, _ = old_records.delete()
+            total_deleted += deleted
+            print(f"Deleted {deleted} records in this batch. Total deleted: {total_deleted}.")
 
         print(f"Deletion complete. Total {total_deleted} PipelineError records older than {days} days deleted.")
         print('Done.')

--- a/figures/management/commands/delete_old_pipeline_error.py
+++ b/figures/management/commands/delete_old_pipeline_error.py
@@ -24,9 +24,17 @@ class Command(BaseCommand):
         days = options['days']
         cutoff_date = now() - timedelta(days=days)
 
-        print(f"Deleting PipelineError records older than {days} days...")
+        print(f"Deleting PipelineError records older than {days} days in batches...")
 
-        deleted_count, _ = PipelineError.objects.filter(created__lt=cutoff_date).delete()
+        batch_size = 1000
+        total_deleted = 0
+        while True:
+            old_records = PipelineError.objects.filter(created__lt=cutoff_date)[:batch_size]
+            if not old_records:
+                break
+            deleted_count = old_records.delete()[0]
+            total_deleted += deleted_count
+            print(f"Deleted {deleted_count} records in this batch. Total deleted: {total_deleted}.")
 
-        print(f"Deleted {deleted_count} PipelineError records older than {days} days.")
+        print(f"Deletion complete. Total {total_deleted} PipelineError records older than {days} days deleted.")
         print('Done.')


### PR DESCRIPTION
This command deletes the records from `figures_pipelineerror` table. It takes `days` as an argument, it is the number of days to retain Pipeline Error records. Defaults to 15.