### PR TITLE
Feat: Add filter to remove deactivate/expired site from figure jobs.

### DIFF
--- a/figures/constants.py
+++ b/figures/constants.py
@@ -10,3 +10,6 @@ PDF_EMAIL_BODY = 'The learners overview report for your platform'
 PDF_NOTE = "*If a learner is converted to a staff user, they will no longer be counted as a learner. However, their \
 learner history will still be included in calculation of course enrollments and completions."
 PDF_EMAIL_SUBJECT = 'Learners Overview Report'
+TRIAL_EXPIRED = 'trial expired'
+DEACTIVATED = 'deactivated'
+EDLY_SAAS = 'edly_saas'

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -959,3 +959,19 @@ def get_course_block_name(course_block_structure, block):
         usage_key=block,
         field_name='type'
     ))
+
+
+def get_site_ids_filter_by_plan(active_sites, exclude_plan):
+    """
+    Returns the site id filter based on the exclude_plan list.
+    """
+    
+    lms_sites = [
+        site.lms_site.id for site in active_sites
+        if hasattr(site.lms_site, 'configuration') and 
+            site.lms_site.configuration.site_values.get(
+                'DJANGO_SETTINGS_OVERRIDE', {}).get(
+                    'CURRENT_PLAN'
+                ) not in exclude_plan
+    ]
+    return lms_sites

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -22,8 +22,9 @@ from openedx.core.djangoapps.content.block_structure.transformers import BlockSt
 from openedx.features.edly.models import EdlySubOrganization, StudentCourseProgress
 
 from figures.backfill import backfill_enrollment_data_for_site
+from figures.constants import DEACTIVATED, TRIAL_EXPIRED
 from figures.compat import CourseEnrollment, CourseOverview
-from figures.helpers import as_course_key, as_date, get_course_block_name
+from figures.helpers import as_course_key, as_date, get_course_block_name, get_site_ids_filter_by_plan
 from figures.log import log_exec_time
 from figures.models import PipelineError
 from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
@@ -193,9 +194,12 @@ def populate_daily_metrics(date_for=None, force_update=False):
     logger.info('Starting task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))
 
-    lms_sites = EdlySubOrganization.objects.using(
-        read_replica_or_default()).filter(is_active=True).values_list('lms_site')
+    active_sites = EdlySubOrganization.objects.using(
+        read_replica_or_default()).filter(is_active=True)
+
+    lms_sites = get_site_ids_filter_by_plan(active_sites, [DEACTIVATED, TRIAL_EXPIRED])
     sites_count = len(lms_sites)
+    logger.info(f"Total number of Site For populate_figures_metrics: {sites_count}")
     for i, site in enumerate(Site.objects.using(read_replica_or_default()).filter(id__in=lms_sites)):
         try:
             courses = figures.sites.get_courses_for_site(site)
@@ -360,7 +364,11 @@ def populate_all_mau():
     Initially, run it every day to observe monthly active user accumulation for
     the month and evaluate the results
     """
-    for site in Site.objects.using(read_replica_or_default()).all():
+    active_sites = EdlySubOrganization.objects.using(
+        read_replica_or_default()).filter(is_active=True)
+
+    lms_sites = get_site_ids_filter_by_plan(active_sites, [DEACTIVATED, TRIAL_EXPIRED])
+    for site in Site.objects.using(read_replica_or_default()).filter(id__in=lms_sites):
         populate_mau_metrics_for_site(site_id=site.id, force_update=False)
 
 
@@ -376,7 +384,11 @@ def run_figures_monthly_metrics():
     TODO: only run for active sites. Requires knowing which sites we can skip
     """
     logger.info('Starting figures.tasks.run_figures_monthly_metrics...')
-    lms_sites = EdlySubOrganization.objects.using(
-        read_replica_or_default()).filter(is_active=True).values_list('lms_site')
+    active_sites = EdlySubOrganization.objects.using(
+        read_replica_or_default()).filter(is_active=True)
+
+    lms_sites = get_site_ids_filter_by_plan(active_sites, [DEACTIVATED, TRIAL_EXPIRED])
+    sites_count = len(lms_sites)
+    logger.info(f"Total number of Site For run_figures_monthly_metrics: {sites_count}")
     for site in Site.objects.using(read_replica_or_default()).filter(id__in=lms_sites):
         populate_monthly_metrics_for_site.delay(site_id=site.id)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 )
 from openedx.features.edly.tests.factories import EdlySubOrganizationFactory
 
+from figures.constants import EDLY_SAAS
 from figures.helpers import as_course_key, as_date
 from figures.models import (
     CourseDailyMetrics,
@@ -31,6 +32,7 @@ from tests.factories import (
     SiteDailyMetricsFactory,
     SiteMonthlyMetricsFactory,
     OrganizationFactory,
+    SiteConfigurationFactory
     )
 
 from six.moves import range
@@ -78,7 +80,13 @@ def test_populate_daily_metrics_site_level_error(transactional_db,
                                                  monkeypatch,
                                                  caplog):
     date_for = '2019-01-02'
-    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=SiteFactory())
+    site = SiteFactory()
+    SiteConfigurationFactory(site=site, site_values={
+        'DJANGO_SETTINGS_OVERRIDE':{
+            'CURRENT_PLAN': EDLY_SAAS
+        }
+    })
+    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=site)
     error_message = dict(message=[u'expected failure'])
     assert not CourseOverview.objects.count()
 
@@ -101,7 +109,13 @@ def test_populate_daily_metrics_site_level_error(transactional_db,
                     reason='Broken test. Apparent Django 1.8 incompatibility')
 def test_populate_daily_metrics_error(transactional_db, monkeypatch):
     date_for = '2019-01-02'
-    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=SiteFactory())
+    site = SiteFactory()
+    SiteConfigurationFactory(site=site, site_values={
+        'DJANGO_SETTINGS_OVERRIDE':{
+            'CURRENT_PLAN': EDLY_SAAS
+        }
+    })
+    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=site)
     error_message = dict(message=[u'expected failure'])
     assert not CourseOverview.objects.count()
 
@@ -138,7 +152,13 @@ def test_populate_daily_metrics_enrollment_data_error(transactional_db,
                                                       monkeypatch,
                                                       caplog):
     date_for = '2019-01-02'
-    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=SiteFactory())
+    site = SiteFactory()
+    SiteConfigurationFactory(site=site, site_values={
+        'DJANGO_SETTINGS_OVERRIDE':{
+            'CURRENT_PLAN': EDLY_SAAS
+        }
+    })
+    EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=site)
     error_message = dict(message=[u'expected failure'])
     assert not CourseOverview.objects.count()
 
@@ -250,6 +270,13 @@ def test_populate_all_mau_multiple_site(transactional_db, monkeypatch):
     assert Site.objects.count() == 1
     sites = [Site.objects.first()]
     sites += [SiteFactory() for i in range(3)]
+    for site in sites:
+        EdlySubOrganizationFactory(edx_organizations=[OrganizationFactory()], lms_site=site)
+        SiteConfigurationFactory(site=site, site_values={
+            'DJANGO_SETTINGS_OVERRIDE':{
+                'CURRENT_PLAN': EDLY_SAAS
+            }
+        })
     sites_visited = []
 
     def mock_populate_mau_metrics_for_site(site_id, force_update=False):


### PR DESCRIPTION
## Change description

The PR adds a filter to remove the sites that are deactivated/expired sites from the daily and monthly metric calculation cron job. 

## Tiaga Ticket:
https://projects.arbisoft.com/project/edly-product/task/7469