### PR TITLE
Add a docker file to run the test case locally for figures.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM circleci/python:3.8
+ENV BASH_ENV=~/.bashrc
+
+WORKDIR ~/circleci-figures
+COPY . ./
+
+RUN pip install --upgrade pip
+RUN pip install virtualenv
+
+RUN virtualenv venv
+RUN . venv/bin/activate
+RUN pip install -r devsite/requirements/py35_juniper.txt
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Change description

Docker container files were created to run the test cases locally. 

- We can use ' pdb/breakpoint` by opening the container through VS Code and do the respective development. 
- Additionally, we can run each test case separately and fix the issue. 

## Commands: 
- Build Image: `docker image build -t figures-test .`
- Connect the Docker image from the VS Code sidebar. 
<img width="358" alt="image" src="https://github.com/user-attachments/assets/e6ae0979-d19e-46c1-b229-3df4e7466912" />

- Run Image: `pytest .` or we can run `pytest tests/test_tasks.py` to run the test cases in a specific file. 

## Dependencies:
Dev Container: https://code.visualstudio.com/docs/devcontainers/containers

Special thanks to @Danyal-Faheem for writing the docker file. 