### PR TITLE
Fix: resolve the issue while install in tutor sumac.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ node_modules
 .idea
 
 frontend/webpack-stats.json
+frontend/.yarn/
 
 # Sublime Text
 
@@ -128,3 +129,4 @@ sandbox
 /scratch.txt
 /notes
 *.bak
+

--- a/figures/compat.py
+++ b/figures/compat.py
@@ -76,7 +76,7 @@ else:  # Assume Hawthorn or greater
 # preemptive addition. Added it here to avoid adding to figures.models
 # In fact, we should probably do a refactoring that makes all Figures import it
 # from here
-from student.models import CourseAccessRole, CourseEnrollment  # noqa pylint: disable=unused-import,import-error
+from common.djangoapps.student.models import CourseAccessRole, CourseEnrollment  # noqa pylint: disable=unused-import,import-error
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # noqa pylint: disable=unused-import,import-error
 
 

--- a/figures/models.py
+++ b/figures/models.py
@@ -12,7 +12,6 @@ from django.contrib.sites.models import Site
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import F
-from django.utils.encoding import python_2_unicode_compatible
 
 from jsonfield import JSONField
 
@@ -32,7 +31,6 @@ def default_site():
     return settings.SITE_ID
 
 
-@python_2_unicode_compatible
 class CourseDailyMetrics(TimeStampedModel):
     """Metrics data specific to an individual course
 
@@ -95,7 +93,6 @@ class CourseDailyMetrics(TimeStampedModel):
         return cls.objects.filter(**filter_args).order_by('-date_for').first()
 
 
-@python_2_unicode_compatible
 class SiteDailyMetrics(TimeStampedModel):
     """
     Stores metrics for a given site and day
@@ -158,7 +155,6 @@ class SiteDailyMetrics(TimeStampedModel):
         return recs[0] if recs else None
 
 
-@python_2_unicode_compatible
 class SiteMonthlyMetrics(TimeStampedModel):
     """
     Stores metrics for a given site and month
@@ -341,7 +337,6 @@ class EnrollmentDataManager(models.Manager):
             return ed_recs[0], False
 
 
-@python_2_unicode_compatible
 class EnrollmentData(TimeStampedModel):
     """Tracks most recent enrollment data for an enrollment
 
@@ -489,7 +484,6 @@ class LearnerCourseGradeMetricsManager(models.Manager):
         return self.raw(statement.format(site=site))
 
 
-@python_2_unicode_compatible
 class LearnerCourseGradeMetrics(TimeStampedModel):
     """This model stores metrics for a learner and course on a given date
 
@@ -624,7 +618,6 @@ class MonthlyActiveEnrollmentManager(models.Manager):
             month_for=month_for)
 
 
-@python_2_unicode_compatible
 class MonthlyActiveEnrollment(TimeStampedModel):
     """Capture enrollment activity for a given month
 
@@ -647,7 +640,6 @@ class MonthlyActiveEnrollment(TimeStampedModel):
             self.id, self.site.domain, self.course_id, self.user.username, self.month_for)
 
 
-@python_2_unicode_compatible
 class PipelineError(TimeStampedModel):
     """
     Captures errors when running Figures pipeline.
@@ -717,7 +709,6 @@ class SiteMauMetricsManager(models.Manager):
         return queryset.order_by('-modified').first()
 
 
-@python_2_unicode_compatible
 class SiteMauMetrics(BaseDateMetricsModel):
 
     mau = models.IntegerField()
@@ -767,7 +758,6 @@ class CourseMauMetricsManager(models.Manager):
         return queryset.order_by('-modified').first()
 
 
-@python_2_unicode_compatible
 class CourseMauMetrics(BaseDateMetricsModel):
     course_id = models.CharField(max_length=255)
     mau = models.IntegerField()

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -17,7 +17,7 @@ import logging
 from dateutil.relativedelta import relativedelta
 from django.db import transaction
 
-from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole  # noqa pylint: disable=import-error
+from common.djangoapps.student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole  # noqa pylint: disable=import-error
 
 from figures.compat import (CourseEnrollment,
                             CourseOverview,

--- a/figures/urls.py
+++ b/figures/urls.py
@@ -4,7 +4,7 @@ Figures URL definitions
 
 from __future__ import absolute_import
 from django import VERSION as DJANGO_VERSION
-from django.conf.urls import include, url
+from django.urls import include, re_path as url
 from rest_framework import routers
 
 from figures import views
@@ -16,54 +16,54 @@ router = routers.DefaultRouter()
 router.register(
     r'course-daily-metrics',
     views.CourseDailyMetricsViewSet,
-    base_name='course-daily-metrics')
+    basename='course-daily-metrics')
 
 router.register(
     r'site-daily-metrics',
     views.SiteDailyMetricsViewSet,
-    base_name='site-daily-metrics')
+    basename='site-daily-metrics')
 
 router.register(
     r'course-monthly-metrics',
     views.CourseMonthlyMetricsViewSet,
-    base_name='course-monthly-metrics')
+    basename='course-monthly-metrics')
 
 router.register(
     r'site-monthly-metrics',
     views.SiteMonthlyMetricsViewSet,
-    base_name='site-monthly-metrics')
+    basename='site-monthly-metrics')
 
 router.register(
     r'course-mau-metrics',
     views.CourseMauMetricsViewSet,
-    base_name='course-mau-metrics')
+    basename='course-mau-metrics')
 
 router.register(
     r'site-mau-metrics',
     views.SiteMauMetricsViewSet,
-    base_name='site-mau-metrics')
+    basename='site-mau-metrics')
 
 router.register(
     r'course-mau-live-metrics',
     views.CourseMauLiveMetricsViewSet,
-    base_name='course-mau-live-metrics')
+    basename='course-mau-live-metrics')
 
 router.register(
     r'site-mau-live-metrics',
     views.SiteMauLiveMetricsViewSet,
-    base_name='site-mau-live-metrics')
+    basename='site-mau-live-metrics')
 
 
 router.register(
     r'admin/sites',
     views.SiteViewSet,
-    base_name='sites')
+    basename='sites')
 
 # Wrappers around edx-platform models
 router.register(
     r'course-enrollments',
     views.CourseEnrollmentViewSet,
-    base_name='course-enrollments')
+    basename='course-enrollments')
 
 
 #
@@ -74,27 +74,27 @@ router.register(
 router.register(
     r'courses-index',
     views.CoursesIndexViewSet,
-    base_name='courses-index')
+    basename='courses-index')
 
 router.register(
     r'courses-general',
     views.GeneralCourseDataViewSet,
-    base_name='courses-general')
+    basename='courses-general')
 
 router.register(
     r'courses-detail',
     views.CourseDetailsViewSet,
-    base_name='courses-detail')
+    basename='courses-detail')
 
 router.register(
     r'users-general',
     views.GeneralUserDataViewSet,
-    base_name='users-general')
+    basename='users-general')
 
 router.register(
     r'users-detail',
     views.LearnerDetailsViewSet,
-    base_name='users-detail')
+    basename='users-detail')
 
 # TODO: Consider changing this path to be 'users' or 'users/summary'
 # So that all user data fall under the same root path
@@ -102,7 +102,7 @@ router.register(
 router.register(
     r'user-index',
     views.UserIndexViewSet,
-    base_name='user-index')
+    basename='user-index')
 
 
 # New endpoints in development (unstable)
@@ -111,17 +111,17 @@ router.register(
 router.register(
     r'enrollment-metrics',
     views.EnrollmentMetricsViewSet,
-    base_name='enrollment-metrics')
+    basename='enrollment-metrics')
 
 router.register(
     r'learner-metrics-v1',
     views.LearnerMetricsViewSetV1,
-    base_name='learner-metrics-v1')
+    basename='learner-metrics-v1')
 
 router.register(
     r'learner-metrics',
     views.LearnerMetricsViewSetV2,
-    base_name='learner-metrics')
+    basename='learner-metrics')
 
 urlpatterns = [
 
@@ -129,7 +129,7 @@ urlpatterns = [
     url(r'^$', views.figures_home, name='figures-home'),
 
     # Non-router API endpoints
-    url(r'^api/general-site-metrics', views.GeneralSiteMetricsView.as_view(),
+    url(r'api/general-site-metrics', views.GeneralSiteMetricsView.as_view(),
         name='general-site-metrics'),
 ]
 

--- a/figures/views.py
+++ b/figures/views.py
@@ -17,7 +17,7 @@ from rest_framework.authentication import (
     SessionAuthentication,
     TokenAuthentication,
 )
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 
@@ -524,7 +524,7 @@ class EnrollmentMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
         queryset = LearnerCourseGradeMetrics.objects.filter(site=site)
         return queryset
 
-    @list_route()
+    @action(detail=False)
     def completed_ids(self, request):
         """Return distinct course id/user id pairs for completed enrollments
 
@@ -542,7 +542,7 @@ class EnrollmentMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
         serializer = CourseCompletedSerializer(qs, many=True)
         return Response(serializer.data)
 
-    @list_route()
+    @action(detail=False)
     def completed(self, request):
         """Experimental endpoint to return completed LCGM records
 
@@ -632,7 +632,7 @@ class CourseMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
                                                 month_for=month_for)
         return Response(data)
 
-    @detail_route()
+    @action(detail=True)
     def active_users(self, request, **kwargs):  # pylint: disable=unused-argument
         site, course_id = self.site_course_helper(kwargs.get('pk', ''))
         date_for = datetime.utcnow().date()
@@ -646,7 +646,7 @@ class CourseMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(active_users=active_users)
         return Response(data)
 
-    @detail_route()
+    @action(detail=True)
     def course_enrollments(self, request, **kwargs):
         site, course_id = self.site_course_helper(kwargs.get('pk', ''))
         data = dict(course_enrollments=self.historic_data(
@@ -656,7 +656,7 @@ class CourseMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
             func=metrics.get_course_enrolled_users_for_time_period))
         return Response(data)
 
-    @detail_route()
+    @action(detail=True)
     def num_learners_completed(self, request, **kwargs):
         site, course_id = self.site_course_helper(kwargs.get('pk', ''))
         data = dict(num_learners_completed=self.historic_data(
@@ -666,7 +666,7 @@ class CourseMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
             func=metrics.get_course_num_learners_completed_for_time_period))
         return Response(data)
 
-    @detail_route()
+    @action(detail=True)
     def avg_days_to_complete(self, request, **kwargs):
         site, course_id = self.site_course_helper(kwargs.get('pk', ''))
         data = dict(avg_days_to_complete=self.historic_data(
@@ -676,7 +676,7 @@ class CourseMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
             func=metrics.get_course_average_days_to_complete_for_time_period))
         return Response(data)
 
-    @detail_route()
+    @action(detail=True)
     def avg_progress(self, request, **kwargs):
         site, course_id = self.site_course_helper(kwargs.get('pk', ''))
         data = dict(avg_progress=self.historic_data(
@@ -714,7 +714,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = metrics.get_current_month_site_metrics(site)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def registered_users(self, request):
         site = figures.sites.get_requested_site(request)
         date_for = datetime.utcnow().date()
@@ -729,7 +729,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(registered_users=registered_users)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def new_users(self, request):
         """
         TODO: Rename the metrics module function to "new_users" to match this
@@ -747,7 +747,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(new_users=new_users)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def course_completions(self, request):
         site = figures.sites.get_requested_site(request)
         date_for = datetime.utcnow().date()
@@ -762,7 +762,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(course_completions=course_completions)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def course_enrollments(self, request):
         site = figures.sites.get_requested_site(request)
         date_for = datetime.utcnow().date()
@@ -777,7 +777,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(course_enrollments=course_enrollments)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def site_courses(self, request):
         site = figures.sites.get_requested_site(request)
         date_for = datetime.utcnow().date()
@@ -792,7 +792,7 @@ class SiteMonthlyMetricsViewSet(CommonAuthMixin, viewsets.ViewSet):
         data = dict(site_courses=site_courses)
         return Response(data)
 
-    @list_route()
+    @action(detail=False)
     def active_users(self, request):
         site = figures.sites.get_requested_site(request)
         months_back = 6


### PR DESCRIPTION
## Description 
- Replace deprecated base_name (DRF 3.10+) with basename in DRF router registrations for compatibility with newer DRF versions.
- Refactor imports from common.djangoapps.student.roles; add linting exceptions to handle import resolution in Sumac. 
- Alias re_path as url to maintain compatibility with legacy url() patterns.
- Refactor DRF viewset decorators: use @action in place of detail_route and list_route for compatibility with DRF 3.9+.
- Remove @python_2_unicode_compatible decorator — no longer needed in Python 3.



