### PR TITLE
Add optimizations to figures daily job

### DIFF
--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -5,13 +5,14 @@ Initially developed to support API performance improvements
 
 from __future__ import absolute_import
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from dateutil.rrule import rrule, MONTHLY
 from dateutil.relativedelta import relativedelta
 
 from django.utils.timezone import utc
 
 from figures.compat import CourseNotFound, StudentModule
+from figures.progress import EnrollmentProgress
 from figures.sites import get_course_enrollments_for_site, get_student_modules_for_site
 from figures.pipeline.site_monthly_metrics import fill_month
 from figures.models import EnrollmentData, LearnerCourseGradeMetrics
@@ -67,9 +68,12 @@ def backfill_enrollment_data_for_site(site):
     records_to_create = []
     records_to_update = []
     errors = []
+    users = []
+    course_ids = []
     site_course_enrollments = get_course_enrollments_for_site(site)
-    users = [e.user for e in site_course_enrollments]
-    course_ids = [str(e.course_id) for e in site_course_enrollments]
+    for e in site_course_enrollments:
+        users.append(e.user)
+        course_ids.append(e.course_id)
 
     # Prepare lookup dictionaries
     latest_grades = LearnerCourseGradeMetrics.objects.bulk_latest_lcgm(users, course_ids)
@@ -98,16 +102,30 @@ def backfill_enrollment_data_for_site(site):
             }
 
             if grade := latest_grades.get(key):
-                defaults.update({
-                    'date_for': grade.date_for,
-                    'is_completed': grade.completed,
-                    'progress_percent': grade.progress_percent,
-                    'points_possible': grade.points_possible,
-                    'points_earned': grade.points_earned,
-                    'sections_possible': grade.sections_possible,
-                    'sections_worked': grade.sections_worked,
-                })
+                progress_data = dict(
+                    date_for=grade.date_for,
+                    is_completed=grade.completed,
+                    progress_percent=grade.progress_percent,
+                    points_possible=grade.points_possible,
+                    points_earned=grade.points_earned,
+                    sections_possible=grade.sections_possible,
+                    sections_worked=grade.sections_worked
+                )
+            else:
+                ep = EnrollmentProgress(user=user, course_id=course_id_str)
+                # TODO: If we get progress worked and there is no LCGM, then we have
+                # a bug OR there was progress after the last daily metrics collection
+                progress_data = dict(
+                    date_for=date.today(),
+                    is_completed=ep.is_completed(),
+                    progress_percent=ep.progress_percent(),
+                    points_possible=ep.progress.get('points_possible', 0),
+                    points_earned=ep.progress.get('points_earned', 0),
+                    sections_possible=ep.progress.get('sections_possible', 0),
+                    sections_worked=ep.progress.get('sections_worked', 0)
+                )
 
+            defaults.update(progress_data)
             # Handle record creation/update
             if existing := existing_data.get(key):
                 records_to_update.append(existing)
@@ -146,7 +164,8 @@ def backfill_course_activity_date(site):
     """
     student_ids = StudentModule.objects.values_list('student__id', flat=True).distinct()
     for student_id in student_ids:
-        student_activity = StudentModule.objects.filter(student__id=student_id).order_by('-modified').first()
+        student_activity = StudentModule.objects.filter(
+            student__id=student_id).order_by('-modified').first()
         EdlyMultiSiteAccess.objects.filter(
             user__id=student_activity.student_id,
             sub_org__lms_site=site,

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -114,21 +114,30 @@ def backfill_enrollment_data_for_site(site):
             else:
                 records_to_create.append(EnrollmentData(**defaults))
 
-        except CourseNotFound:
-            msg = ('CourseNotFound for course "{course}". '
-                   ' CourseEnrollment ID={ce_id}')
-            errors.append(msg.format(course=str(rec.course_id),
-                                     ce_id=rec.id))
+        except Exception as e:
+            msg = (
+                'Error processing course enrollment for user %s in course %s: %s',
+                rec.user.id, rec.course_id, e
+            )
+            errors.append(msg)
+            logger.error(msg)
 
     # Bulk operations
-    EnrollmentData.objects.bulk_create(records_to_create)
-    fields = [f.name for f in EnrollmentData._meta.fields if f.name not in ('id')]
-    EnrollmentData.objects.bulk_update(records_to_update, fields)
+    try:
+        EnrollmentData.objects.bulk_create(records_to_create)
+        fields_to_update = [
+            'is_enrolled', 'date_enrolled', 'date_for', 'is_completed',
+            'progress_percent', 'points_possible', 'points_earned',
+            'sections_possible', 'sections_worked'
+        ]
+        EnrollmentData.objects.bulk_update(records_to_update, fields_to_update)
+    except Exception as e:
+        logger.exception('Error during bulk operations: %s', e)
 
-    results = list(zip(records_to_create, [True] * len(records_to_create))) + \
+    enrollment_data = list(zip(records_to_create, [True] * len(records_to_create))) + \
         list(zip(records_to_update, [False] * len(records_to_update)))
 
-    return dict(results=results, errors=errors)
+    return dict(results=enrollment_data, errors=errors)
 
 
 def backfill_course_activity_date(site):

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -64,23 +64,71 @@ def backfill_enrollment_data_for_site(site):
     Potential improvements: iterate by course id within site, have a function
     specific to a course. more queries, but breaks up the work
     """
-    enrollment_data = []
+    records_to_create = []
+    records_to_update = []
     errors = []
     site_course_enrollments = get_course_enrollments_for_site(site)
+    users = [e.user for e in site_course_enrollments]
+    course_ids = [str(e.course_id) for e in site_course_enrollments]
+
+    # Prepare lookup dictionaries
+    latest_grades = LearnerCourseGradeMetrics.objects.bulk_latest_lcgm(users, course_ids)
+    existing_data = {
+        (ed.user_id, ed.course_id): ed
+        for ed in EnrollmentData.objects.filter(
+            site=site,
+            user__in=users,
+            course_id__in=course_ids
+        )
+    }
+
     for rec in site_course_enrollments:
         try:
-            obj, created = EnrollmentData.objects.set_enrollment_data(
-                site=site,
-                user=rec.user,
-                course_id=rec.course_id)
-            enrollment_data.append((obj, created))
+            user = rec.user
+            course_id_str = str(rec.course_id)
+            key = (user.id, course_id_str)
+
+            # Prepare base data
+            defaults = {
+                'site': site,
+                'user': user,
+                'course_id': course_id_str,
+                'is_enrolled': rec.is_active,
+                'date_enrolled': rec.created,
+            }
+
+            if grade := latest_grades.get(key):
+                defaults.update({
+                    'date_for': grade.date_for,
+                    'is_completed': grade.completed,
+                    'progress_percent': grade.progress_percent,
+                    'points_possible': grade.points_possible,
+                    'points_earned': grade.points_earned,
+                    'sections_possible': grade.sections_possible,
+                    'sections_worked': grade.sections_worked,
+                })
+
+            # Handle record creation/update
+            if existing := existing_data.get(key):
+                records_to_update.append(existing)
+            else:
+                records_to_create.append(EnrollmentData(**defaults))
+
         except CourseNotFound:
             msg = ('CourseNotFound for course "{course}". '
                    ' CourseEnrollment ID={ce_id}')
             errors.append(msg.format(course=str(rec.course_id),
                                      ce_id=rec.id))
 
-    return dict(results=enrollment_data, errors=errors)
+    # Bulk operations
+    EnrollmentData.objects.bulk_create(records_to_create)
+    fields = [f.name for f in EnrollmentData._meta.fields if f.name not in ('id')]
+    EnrollmentData.objects.bulk_update(records_to_update, fields)
+
+    results = list(zip(records_to_create, [True] * len(records_to_create))) + \
+        list(zip(records_to_update, [False] * len(records_to_update)))
+
+    return dict(results=results, errors=errors)
 
 
 def backfill_course_activity_date(site):
@@ -89,7 +137,8 @@ def backfill_course_activity_date(site):
     """
     student_ids = StudentModule.objects.values_list('student__id', flat=True).distinct()
     for student_id in student_ids:
-        student_activity = StudentModule.objects.filter(student__id=student_id).order_by('-modified').first()
+        student_activity = StudentModule.objects.filter(
+            student__id=student_id).order_by('-modified').first()
         EdlyMultiSiteAccess.objects.filter(
             user__id=student_activity.student_id,
             sub_org__lms_site=site,

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -127,8 +127,8 @@ def backfill_enrollment_data_for_site(site):
 
             defaults.update(progress_data)
             # Handle record creation/update
-            if existing := existing_data.get(key):
-                records_to_update.append(existing)
+            if existing_data.get(key):
+                records_to_update.append(defaults)
             else:
                 records_to_create.append(EnrollmentData(**defaults))
 

--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -137,8 +137,7 @@ def backfill_course_activity_date(site):
     """
     student_ids = StudentModule.objects.values_list('student__id', flat=True).distinct()
     for student_id in student_ids:
-        student_activity = StudentModule.objects.filter(
-            student__id=student_id).order_by('-modified').first()
+        student_activity = StudentModule.objects.filter(student__id=student_id).order_by('-modified').first()
         EdlyMultiSiteAccess.objects.filter(
             user__id=student_activity.student_id,
             sub_org__lms_site=site,

--- a/figures/models.py
+++ b/figures/models.py
@@ -4,6 +4,7 @@ TODO: Create a base "SiteModel" or a "SiteModelMixin"
 """
 
 from __future__ import absolute_import
+from django.db.models import OuterRef, Subquery, Max
 import logging
 import time
 from datetime import date
@@ -345,6 +346,38 @@ class LearnerCourseGradeMetricsManager(models.Manager):
         queryset = self.filter(user=user,
                                course_id=str(course_id)).order_by('-date_for')
         return queryset[0] if queryset else None
+
+    def bulk_latest_lcgm(self, user_ids, course_ids):
+        """
+        Gets the most recent records for the given users and courses in bulk.
+        Returns a dictionary mapping (user_id, course_id) tuples to their latest record.
+
+        Args:
+            user_ids: List/QuerySet of user IDs
+            course_ids: List/QuerySet of course IDs (as strings)
+
+        Returns:
+            dict: {(user_id, course_id): latest_lcgm_record}
+        """
+        # Subquery to find the latest date_for for each user-course pair
+        latest_dates = self.filter(
+            user_id=OuterRef('user_id'),
+            course_id=OuterRef('course_id')
+        ).values('user_id', 'course_id').annotate(
+            latest_date=Max('date_for')
+        ).values('latest_date')[:1]
+
+        # Main query to get full records with the latest dates
+        queryset = self.filter(
+            user_id__in=user_ids,
+            course_id__in=course_ids,
+            date_for=Subquery(latest_dates)
+        ).order_by('user_id', 'course_id', '-date_for')
+
+        return {
+            (lcgm.user_id, lcgm.course_id): lcgm
+            for lcgm in queryset
+        }
 
     def most_recent_for_course(self, course_id):
         statement = """ \

--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -404,6 +404,5 @@ class CourseDailyMetricsLoader(object):
             # record not found, move on to creating
             pass
 
-        update_learners_activity_for_date(date_for=date_for, site=self.site)
         data = self.get_data(date_for=date_for)
         return self.save_metrics(date_for=date_for, data=data)

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -27,7 +27,7 @@ from figures.compat import CourseEnrollment, CourseOverview
 from figures.helpers import as_course_key, as_date, get_course_block_name, get_site_ids_filter_by_plan
 from figures.log import log_exec_time
 from figures.models import PipelineError
-from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
+from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader, update_learners_activity_for_date
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 from figures.pipeline.mau_pipeline import collect_course_mau
 from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month
@@ -235,6 +235,7 @@ def populate_daily_metrics(date_for=None, force_update=False):
                     logger=logger,
                     log_pipeline_errors_to_db=True,
                     )
+            update_learners_activity_for_date(date_for=date_for, site=site)
 
         populate_site_daily_metrics(
                 site_id=site.id,

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -235,8 +235,8 @@ def populate_daily_metrics(date_for=None, force_update=False):
                     logger=logger,
                     log_pipeline_errors_to_db=True,
                     )
-            update_learners_activity_for_date(date_for=date_for, site=site)
 
+        update_learners_activity_for_date(date_for=date_for, site=site)
         populate_site_daily_metrics(
                 site_id=site.id,
                 date_for=date_for,


### PR DESCRIPTION
## Description
This PR is for the optimization of our daily job for updating figures `populate_daily_metrics` It takes around 11 hours to complete on prod. 

This PR:
- Refactors the code to do bulk update and bulk create on `figures_enrollmentdata` This reduces queries that were executing on each enrollment separately.
- It moves `update_learners_activity_for_date` from inside a loop over courses to outside of the loop which is over sites. This function executes on site level and has no course specific processing. Executing this function for each course was redundant and was slowing down the figures job.  


These changes have reduced the jobs time from around 11-13 minutes to 8 to 8.30 minutes. We should see better improvement on prod since it has much more data.

## Ticket
https://projects.arbisoft.com/project/edly-product/task/7068