### PR TITLE
Fix: move site specific code outside of courses loop

### DIFF
--- a/figures/pipeline/course_daily_metrics.py
+++ b/figures/pipeline/course_daily_metrics.py
@@ -404,6 +404,5 @@ class CourseDailyMetricsLoader(object):
             # record not found, move on to creating
             pass
 
-        update_learners_activity_for_date(date_for=date_for, site=self.site)
         data = self.get_data(date_for=date_for)
         return self.save_metrics(date_for=date_for, data=data)

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -234,9 +234,9 @@ def populate_daily_metrics(date_for=None, force_update=False):
                     site=site,
                     logger=logger,
                     log_pipeline_errors_to_db=True,
-                    )
-            update_learners_activity_for_date(date_for=date_for, site=site)
+                )
 
+        update_learners_activity_for_date(date_for=date_for, site=site)
         populate_site_daily_metrics(
                 site_id=site.id,
                 date_for=date_for,

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -27,7 +27,7 @@ from figures.compat import CourseEnrollment, CourseOverview
 from figures.helpers import as_course_key, as_date, get_course_block_name, get_site_ids_filter_by_plan
 from figures.log import log_exec_time
 from figures.models import PipelineError
-from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
+from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader, update_learners_activity_for_date
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 from figures.pipeline.mau_pipeline import collect_course_mau
 from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month
@@ -235,6 +235,7 @@ def populate_daily_metrics(date_for=None, force_update=False):
                     logger=logger,
                     log_pipeline_errors_to_db=True,
                     )
+            update_learners_activity_for_date(date_for=date_for, site=site)
 
         populate_site_daily_metrics(
                 site_id=site.id,


### PR DESCRIPTION
## Description
This PR is for the optimization of our daily job for updating figures populate_daily_metrics It takes around 11 hours to complete on prod.

- It moves update_learners_activity_for_date from inside a loop over courses to outside of the loop which is over sites. This function executes on site level and has no course specific processing. Executing this function for each course was redundant and was slowing down the figures job.