### PR TITLE
fix: fix all remaining figures jobs

### DIFF
--- a/figures/backfill.py
+++ b/figures/backfill.py
@@ -52,7 +52,7 @@ def backfill_monthly_metrics_for_site(site, overwrite=False):
                                   overwrite=overwrite)
         backfilled.append(dict(obj=obj, created=created, dt=dt))
 
-    backfill_learners_course_data_for_site(site)
+    backfill_learners_course_data_for_site(site.domain)
 
     return backfilled
 

--- a/figures/filters.py
+++ b/figures/filters.py
@@ -250,6 +250,15 @@ class CourseOverviewFilter(django_filters.FilterSet):
     number_contains = char_filter(field_name='display_number_with_default',
                                   lookup_expr='icontains')
 
+    course_id = char_method_filter(method='filter_course_id')
+
+    def filter_course_id(self, queryset, name, value):  # pylint: disable=unused-argument
+        """
+        Filter by Course ID
+        """
+        course_key = CourseKey.from_string(value.replace(' ', '+'))
+        return queryset.filter(id=course_key).using(read_replica_or_default())
+
     class Meta:
         model = CourseOverview
         fields = ['display_name', 'org', 'number', 'number_contains', ]

--- a/figures/management/commands/backfill_figures_daily_metrics.py
+++ b/figures/management/commands/backfill_figures_daily_metrics.py
@@ -9,10 +9,13 @@ from __future__ import absolute_import
 
 from textwrap import dedent
 
+import datetime
 from dateutil.rrule import rrule, DAILY
+from pytz import utc
 
 from django.core.management.base import BaseCommand, CommandError
 
+from edly_features_app.utils import get_active_tenant_lms_sites
 from figures.helpers import as_date
 from figures.sites import Site
 from figures.pipeline.backfill import backfill_daily_metrics_for_site_and_date
@@ -56,6 +59,16 @@ class Command(BaseCommand):
             filter_arg = dict(domain=identifier)
         return Site.objects.get(**filter_arg)
 
+    def get_sites(self, options):
+        """Return list of Site objects to process
+        
+        If site is specified, return that site. Otherwise return all active tenant sites.
+        """
+        if options.get('site'):
+            return [self.get_site(options)]
+        else:
+            return list(get_active_tenant_lms_sites())
+
     def get_dates(self, options):
         """Return a list of dates
         """
@@ -63,8 +76,8 @@ class Command(BaseCommand):
             raise CommandError(
                 'Select either "--date" or "--date-range" option, but not both')
         if not options['date'] and not options['date_range']:
-            raise CommandError(
-                'You need to select one of "--date" or "--date-range" parameters')
+            date_for = datetime.datetime.utcnow().replace(tzinfo=utc).date()
+            return [date_for]
         if options['date']:
             return [as_date(options['date'])]
         else:
@@ -75,10 +88,10 @@ class Command(BaseCommand):
                                               until=dates[1])]
 
     def add_arguments(self, parser):
-        parser.add_argument('site', help='Site domain or id')
+        parser.add_argument('site', nargs='?', default=None, help='Site domain or id (optional, processes all active tenant sites if not specified)')
 
-        parser.add_argument('--date', help='Run backfill for a single date')
-        parser.add_argument('--date-range', nargs=2,
+        parser.add_argument('--date', default=None, help='Run backfill for a single date')
+        parser.add_argument('--date-range', nargs=2, default=None,
                             help='Run backfill from a start date to an end date')
 
         # by default we process the SDM. If we do not want to, set this flag
@@ -90,18 +103,20 @@ class Command(BaseCommand):
                             help='altnerate path to output log files')
 
     def handle(self, *args, **options):
-        site = self.get_site(options)
+        sites = self.get_sites(options)
         dates = self.get_dates(options)
         backfill_options = ['skip_sdm', 'force_update', 'logdir']
         extra_args = dict((key, options[key]) for key in backfill_options)
         # import pdb; pdb.set_trace()
 
-        for date_for in dates:
-            print('Generating daily metrics for date: {}'.format(date_for.isoformat()))
-            results = self.do_backfill(site=site,
-                                       date_for=date_for,
-                                       **extra_args)
-            print('Finished date {}. Processed {} courses'.format(
-                date_for.isoformat(), results['courses_processed']))
-            print('CDM processing time: {}, SDM processing time: {}'.format(
-                results['cdms_elapsed'], results['sdm_elapsed']))
+        for site in sites:
+            print('Processing site: {}'.format(site.domain))
+            for date_for in dates:
+                print('Generating daily metrics for date: {}'.format(date_for.isoformat()))
+                results = self.do_backfill(site=site,
+                                           date_for=date_for,
+                                           **extra_args)
+                print('Finished date {}. Processed {} courses'.format(
+                    date_for.isoformat(), results['courses_processed']))
+                print('CDM processing time: {}, SDM processing time: {}'.format(
+                    results['cdms_elapsed'], results['sdm_elapsed']))

--- a/figures/management/commands/populate_figures_metrics.py
+++ b/figures/management/commands/populate_figures_metrics.py
@@ -69,14 +69,14 @@ class Command(BaseCommand):
             call_command('run_figures_mau_metrics', no_delay=options['no_delay'])
         else:
             # Validate that site is provided when not using --mau option
-            if not options['site']:
-                self.stderr.write(
-                    self.style.ERROR(
-                        'Error: --site argument is required when not using --mau option.\n'
-                        'Please provide a site domain or id using --site <site_domain_or_id>'
-                    )
-                )
-                return
+            # if not options['site']:
+            #     self.stderr.write(
+            #         self.style.ERROR(
+            #             'Error: --site argument is required when not using --mau option.\n'
+            #             'Please provide a site domain or id using --site <site_domain_or_id>'
+            #         )
+            #     )
+            #     return
 
             call_command(
                 'backfill_figures_daily_metrics',
@@ -84,8 +84,8 @@ class Command(BaseCommand):
                 # date_start=options['date'],
                 # date_end=options['date'],
                 # overwrite=options['force_update'],
-                options['site'], 
-                date=options['date'],
+                # options['site'], 
+                # date=options['date'],
                 force_update=options['force_update'],
                 # experimental=options['experimental']
             )

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -12,6 +12,7 @@ from celery.utils.log import get_task_logger
 from completion.models import BlockCompletion
 from django.contrib.sites.models import Site
 from django.utils.timezone import utc
+from edly_features_app.utils import get_active_tenant_lms_sites
 import six
 from edx_django_utils.db.read_replica import read_replica_or_default
 
@@ -205,10 +206,9 @@ def populate_daily_metrics(site_id=None, date_for=None, force_update=False):
     logger.info('Starting task "figures.populate_daily_metrics" for date "{}"'.format(
         date_for))
 
-    lms_sites = EdlySubOrganization.objects.using(
-        read_replica_or_default()).filter(is_active=True).values_list('lms_site')
+    lms_sites = get_active_tenant_lms_sites()
     sites_count = len(lms_sites)
-    for i, site in enumerate(Site.objects.using(read_replica_or_default()).filter(id__in=lms_sites)):
+    for i, site in enumerate(lms_sites):
         try:
             courses = figures.sites.get_courses_for_site(site)
         except Exception:  # pylint: disable=broad-except
@@ -393,7 +393,6 @@ def run_figures_monthly_metrics():
     TODO: only run for active sites. Requires knowing which sites we can skip
     """
     logger.info('Starting figures.tasks.run_figures_monthly_metrics...')
-    lms_sites = EdlySubOrganization.objects.using(
-        read_replica_or_default()).filter(is_active=True).values_list('lms_site')
-    for site in Site.objects.using(read_replica_or_default()).filter(id__in=lms_sites):
+    lms_sites = get_active_tenant_lms_sites()
+    for site in lms_sites:
         populate_monthly_metrics_for_site.delay(site_id=site.id)

--- a/figures/views.py
+++ b/figures/views.py
@@ -176,7 +176,7 @@ class CourseOverviewViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = CourseOverviewSerializer
     pagination_class = FiguresLimitOffsetPagination
     filter_backends = (DjangoFilterBackend, )
-    filter_class = CourseOverviewFilter
+    filterset_class = CourseOverviewFilter
     lookup_value_regex = settings.COURSE_ID_PATTERN
 
     def get_queryset(self):
@@ -228,7 +228,7 @@ class UserIndexViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = UserIndexSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     def get_queryset(self):
         site = figures.sites.get_requested_site(self.request)
@@ -241,7 +241,7 @@ class CourseEnrollmentViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresPageLevelPagination
     serializer_class = CourseEnrollmentSerializer
     filter_backends = (DjangoFilterBackend, SearchFilter, OrderingFilter, )
-    filter_class = CourseEnrollmentFilter
+    filterset_class = CourseEnrollmentFilter
     search_fields = ['user__profile__name', 'user__username', 'user__email']
     ordering_fields = ['user__profile__name', 'user__username', 'user__email', 'user__date_joined', 'user__last_login']
 
@@ -266,7 +266,7 @@ class CourseDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = CourseDailyMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = CourseDailyMetricsFilter
+    filterset_class = CourseDailyMetricsFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -280,7 +280,7 @@ class SiteDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = SiteDailyMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = SiteDailyMetricsFilter
+    filterset_class = SiteDailyMetricsFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -441,7 +441,7 @@ class GeneralCourseDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresPageLevelPagination
     serializer_class = GeneralCourseDataSerializer
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
-    filter_class = CourseOverviewFilter
+    filterset_class = CourseOverviewFilter
     search_fields = ['display_name', 'id']
     ordering_fields = ['display_name', 'self_paced', 'date_joined']
 
@@ -525,7 +525,7 @@ class CourseDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresKiloPagination
     serializer_class = CourseDetailsSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = CourseOverviewFilter
+    filterset_class = CourseOverviewFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -575,7 +575,7 @@ class GeneralUserDataViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresKiloPagination
     serializer_class = GeneralUserDataSerializer
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
     search_fields = ['username', 'email', 'profile__name']
     ordering_fields = ['username', 'email', 'profile__name', 'is_active', 'date_joined']
 
@@ -589,7 +589,7 @@ class LearnerDetailsPDFViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = get_user_model()
     serializer_class = LearnerDetailsSerializer
     ordering_fields = ['profile__name', 'username', 'email', 'is_active', 'date_joined']
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -644,7 +644,7 @@ class LearnerDetailsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend, CustomLearnerSearchFilter, NullsLastOrderingFilter, )
     search_fields = ['profile__name', 'username', 'email']
     ordering_fields = ['profile__name', 'username', 'email', 'is_active', 'date_joined', 'last_login', ]
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     def paginate_queryset(self, queryset, view=None):
         """
@@ -696,7 +696,7 @@ class LearnerDetailsViewSetV2(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend, CustomLearnerSearchFilter, NullsLastOrderingFilter, )
     search_fields = ['profile__name', 'username', 'email']
     ordering_fields = ['profile__name', 'username', 'email', 'is_active', 'date_joined', 'last_login', ]
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     def paginate_queryset(self, queryset, view=None):
         """
@@ -752,7 +752,7 @@ class LearnerMetricsViewSetV1(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
 
     # TODO: Improve this filter
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     search_fields = ['username', 'email', 'profile__name']
     ordering_fields = ['username', 'email', 'profile__name', 'is_active', 'date_joined']
@@ -826,7 +826,7 @@ class LearnerMetricsViewSetV2(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = LearnerMetricsSerializerV2
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
-    filter_class = UserFilterSet
+    filterset_class = UserFilterSet
 
     search_fields = ['username', 'email', 'profile__name']
     ordering_fields = [
@@ -883,7 +883,7 @@ class EnrollmentMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend, )
     # Assess updating to "EnrollmentFilterSet" to filter on list of courses and
     # or users, so we can use it to build a filterable table of users, courses
-    filter_class = EnrollmentMetricsFilter
+    filterset_class = EnrollmentMetricsFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -1257,7 +1257,7 @@ class CourseMauMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = CourseMauMetrics
     serializer_class = CourseMauMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = CourseMauMetricsFilter
+    filterset_class = CourseMauMetricsFilter
     lookup_value_regex = settings.COURSE_ID_PATTERN
 
     def get_queryset(self):
@@ -1271,7 +1271,7 @@ class SiteMauMetricsViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     model = SiteMauMetrics
     serializer_class = SiteMauMetricsSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = SiteMauMetricsFilter
+    filterset_class = SiteMauMetricsFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)
@@ -1288,7 +1288,7 @@ class SiteViewSet(StaffUserOnDefaultSiteAuthMixin, viewsets.ReadOnlyModelViewSet
     pagination_class = FiguresLimitOffsetPagination
     serializer_class = SiteSerializer
     filter_backends = (DjangoFilterBackend, )
-    filter_class = SiteFilterSet
+    filterset_class = SiteFilterSet
 
     def get_queryset(self):
         return figures.sites.get_sites()


### PR DESCRIPTION
## Description

- Modified backfill_monthly_metrics_for_site to accept site.domain.
- Replaced direct LMS site queries with get_active_tenant_lms_sites in populate_daily_metrics and run_figures_monthly_metrics.
- Enhanced backfill_figures_daily_metrics command to process all active tenant sites if no specific site is provided.
- Cleaned up error handling for site argument in populate_figures_metrics command.