### PR TITLE
Fix: resolve tenant external_key lookup using TenantConfig instead of domain split

### DIFF
--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -73,6 +73,8 @@ from rest_framework.response import Response
 from dateutil.parser import parse as dateutil_parse
 from dateutil.relativedelta import relativedelta
 from eox_tenant.edxapp_wrapper.site_configuration_module import get_configuration_helpers
+from eox_tenant.models import TenantConfig
+from eox_tenant.constants import LMS_CONFIG_COLUMN
 
 from opaque_keys.edx.keys import CourseKey
 import six
@@ -1000,15 +1002,13 @@ def get_course_block_name(course_block_structure, block):
     ))
 
 
-def get_tenant_external_key(request):
+def get_external_key_for_site(site):
     """
-    Get the external keys for the current tenant from the request.
+    Resolve TenantConfig external_key for the given site.
+    Falls back to first subdomain if TenantConfig lookup fails.
     """
-    site = get_current_site(request)
-    tenent_keys = request.GET.get('sub_org', '')
-    tenent_keys = [site.domain.split('.')[0]] if not tenent_keys else tenent_keys.split(',')
-    return tenent_keys
-
+    _, external_key = TenantConfig.get_configs_for_domain(site.domain, LMS_CONFIG_COLUMN)
+    return external_key if external_key else site.domain.split('.')[0]
 
 def get_tenant_external_keys(request):
     """
@@ -1016,7 +1016,7 @@ def get_tenant_external_keys(request):
     """
     site = get_current_site(request)
     tenent_keys = request.GET.get('sub_org', '')
-    tenent_keys = [site.domain.split('.')[0]] if not tenent_keys else tenent_keys.split(',')
+    tenent_keys = [get_external_key_for_site(site)] if not tenent_keys else tenent_keys.split(',')
     return tenent_keys
 
 

--- a/figures/serializers.py
+++ b/figures/serializers.py
@@ -36,7 +36,7 @@ from figures.compat import (RELEASE_LINE,
                             CourseEnrollment,
                             CourseOverview,
                             GeneratedCertificate)
-from figures.helpers import as_course_key, get_date
+from figures.helpers import as_course_key, get_date, get_external_key_for_site
 from figures.metrics import (
     get_course_enrolled_users_for_time_period,
     get_course_average_progress_for_time_period,
@@ -844,9 +844,9 @@ class LearnerDetailsSerializer(serializers.ModelSerializer):
                 return None
             site = self.context['site']
 
-        external_key = site.domain.split('.')[0]
+        external_key = get_external_key_for_site(site)
         edly_access_user = user.edly_multisite_user.get(
-            tenant__tenant_config__external_key=external_key 
+            tenant__tenant_config__external_key=external_key
         )
         return edly_access_user.course_activity_date
     

--- a/figures/sites.py
+++ b/figures/sites.py
@@ -28,7 +28,7 @@ from edly_features_app.models import (
     EdlyMultiSiteAccess
 )  # pylint: disable=import-error
 from figures.compat import CourseEnrollment, GeneratedCertificate, StudentModule
-from figures.helpers import as_course_key, is_multisite, import_from_path
+from figures.helpers import as_course_key, is_multisite, import_from_path, get_external_key_for_site
 import figures.helpers
 from edx_django_utils.db.read_replica import read_replica_or_default
 from eox_tenant.models import TenantConfig
@@ -275,7 +275,7 @@ def get_user_ids_for_sites(tenant_external_keys):
 
 def get_user_ids_for_site(site):
     if figures.helpers.is_multisite():
-        tenant_external_key = site.domain.split('.')[0]
+        tenant_external_key = get_external_key_for_site(site)
         edly_access_users = EdlyMultiSiteAccess.objects.filter(
             tenant__tenant_config__external_key=tenant_external_key
         ).using(read_replica_or_default()).exclude(
@@ -291,7 +291,7 @@ def get_user_ids_for_site(site):
 
 
 def get_edly_users_for_site(site):
-    tenant_external_key = site.domain.split('.')[0]
+    tenant_external_key = get_external_key_for_site(site)
     if figures.helpers.is_multisite():
         user_ids = get_user_model().objects.select_related(
             'profile',
@@ -329,7 +329,7 @@ def get_users_for_site(site):
 
 
 def get_course_enrollments_for_site(site):
-    tenent_keys = [site.domain.split('.')[0]]
+    tenent_keys = [get_external_key_for_site(site)]
     course_keys = get_course_keys_for_site(tenent_keys)
     return CourseEnrollment.objects.filter(
         course_id__in=course_keys,


### PR DESCRIPTION
## Problem

Several Figures functions derived the tenant \`external_key\` by splitting \`site.domain\` on \`.\` and taking the first segment (e.g. \`upgrade\` from \`upgrade.theologyx.com\`). This breaks when a site's \`TenantConfig.external_key\` doesn't match its subdomain, causing:

- \`/figures/api/courses/general/\` returning \`{"count": 0}\` with data present
- Incorrect user/enrollment querysets across Figures APIs
- Wrong \`course_activity_date\` lookups in serializers

## Root Cause

\`TenantConfig.external_key\` is the authoritative key used throughout \`eox_tenant\`. It is not guaranteed to match the first subdomain segment. Affected functions:

- \`get_tenant_external_keys\` (helpers.py)
- \`get_user_ids_for_site\` (sites.py)
- \`get_edly_users_for_site\` (sites.py)
- \`get_course_enrollments_for_site\` (sites.py)
- \`LearnerDetailsSerializer.get_course_activity_date\` (serializers.py)

## Fix

Introduced \`get_external_key_for_site(site)\` in \`helpers.py\` that resolves the authoritative \`external_key\` via \`TenantConfig.get_configs_for_domain\` — a single optimized raw SQL query on the indexed \`eox_tenant_route.domain\` column. Falls back to subdomain split only if no TenantConfig is found.

Also removed dead code \`get_tenant_external_key\` (singular) — no callers.