### PR TITLE
fix: Wire CSV reports to edly_features_app StudentCourseProgress

### DIFF
--- a/figures/edly_views/edly_reports.py
+++ b/figures/edly_views/edly_reports.py
@@ -233,6 +233,7 @@ class InsightLearnersCSV(APIView):
         Prepare raw data for learner insights
         """
         site_obj = Site.objects.get(id=site)
+        context['site'] = site_obj
         context['course_enrollments'] = figures.sites.get_course_enrollments_for_site(
             site_obj
         )

--- a/figures/edly_views/edly_reports.py
+++ b/figures/edly_views/edly_reports.py
@@ -8,13 +8,13 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.http.request import HttpRequest
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
+from edly_features_app.models import StudentCourseProgress
 from edly_panel_app.api.v1.views import (
     GetMonthlyActiveUsers, GetMonthlyCourseCompletions
 )
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration
 from openedx.core.lib.api.authentication import OAuth2Authentication
-# from openedx.features.edly.models import StudentCourseProgress
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import NotFound
@@ -378,7 +378,9 @@ class InsightCoursesCSV(APIView):
         course_enrollments = InsightCoursesCSV._get_course_enrollments(fake_req)
         course_enrollments = InsightCoursesCSV._get_serialized_enrollments(course_enrollments)
 
-        scp_objects = StudentCourseProgress.objects.filter(course_id=course_id)
+        scp_objects = StudentCourseProgress.objects.filter(
+            course_id=CourseKey.from_string(course_id.replace(' ', '+'))
+        )
         course_maus = InsightCoursesCSV._get_courses_maus(site, course_id)
         figures.helpers.send_insights_course_detail_report(
             course_overview, course_details, course_maus, course_enrollments,

--- a/figures/helpers.py
+++ b/figures/helpers.py
@@ -763,7 +763,7 @@ def send_insights_learner_report(raw_data, recipient_email, username, report_typ
             len([course for course in learner['courses'] if course['progress_data']['course_completed']]),
             (learner.get('date_joined') or 'N/A').split('T')[0],
             (learner.get('last_login') or 'N/A').split('T')[0],
-            (learner.get('course_activity_date') or 'N/A').split(' ')[0]
+            str(learner.get('course_activity_date') or 'N/A').split(' ')[0]
         ])
 
     csv_report_writer.writerow([''])
@@ -837,7 +837,7 @@ def get_farthest_complete_course_block(scp_objects, course_key=None, user=None):
         scp = course_progress.first()
         return [scp.completed_section, scp.completed_subsection, scp.completed_unit, scp.completed_block, scp.completion_date]
 
-    return []
+    return ['N/A', 'N/A', 'N/A', 'N/A', 'N/A']
 
 
 def send_learner_report(learners_data, scp_objects, recipient_email, username, report_type, site_configs):
@@ -865,7 +865,7 @@ def send_learner_report(learners_data, scp_objects, recipient_email, username, r
     csv_report_writer.writerow(['Last Login', last_login])
     course_activity = learners_data.get('course_activity_date')
     csv_report_writer.writerow([
-        'Last Course Activity', course_activity.split(' ')[0] if course_activity else 'N/A'
+        'Last Course Activity', str(course_activity).split(' ')[0] if course_activity else 'N/A'
     ])
     csv_report_writer.writerow([''])
     csv_report_writer.writerow([

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -14,21 +14,18 @@ from datetime import timezone
 from edly_features_app.tasks import update_student_course_progress_for_course
 from edly_features_app.utils import get_active_tenant_lms_sites
 import six
-from edx_django_utils.db.read_replica import read_replica_or_default
 
 from figures.backfill import backfill_enrollment_data_for_site
 from figures.compat import CourseEnrollment, CourseOverview
 from figures.helpers import as_course_key, as_date
 from figures.log import log_exec_time
 from figures.models import PipelineError
-from figures.helpers import as_course_key, as_date, is_past_date, is_multisite
-from figures.sites import default_site, get_sites, get_sites_by_id, site_course_ids
+from figures.sites import default_site
 import figures.sites
 from figures.pipeline.backfill import backfill_enrollment_data_for_site
 from figures.pipeline.course_daily_metrics import CourseDailyMetricsLoader
 from figures.pipeline.site_daily_metrics import SiteDailyMetricsLoader
 from figures.pipeline.mau_pipeline import collect_course_mau
-from figures.pipeline.helpers import DateForCannotBeFutureError
 from figures.pipeline.site_monthly_metrics import fill_last_month as fill_last_smm_month
 from figures.pipeline.logger import log_error_to_db
 from edx_django_utils.db.read_replica import read_replica_or_default
@@ -111,15 +108,13 @@ def update_enrollment_data(site_id, **_kwargs):
 
 
 @shared_task
-def update_learners_progress_for_course(course):
-    """
-    Recompute ``StudentCourseProgress`` rows for every active enrollment
-    in the given course.
+def update_learners_progress_for_course(course_id):
+    """Recompute StudentCourseProgress rows for every active enrollment in a course.
 
     Delegates to ``edly_features_app.tasks.update_student_course_progress_for_course``
     where the SCP model and traversal logic live.
     """
-    update_student_course_progress_for_course(str(course.id))
+    update_student_course_progress_for_course.delay(str(course_id))
 
 
 @shared_task
@@ -169,7 +164,7 @@ def populate_daily_metrics(site_id=None, date_for=None, force_update=False):
                     course_id=course.id,
                     date_for=date_for,
                     force_update=force_update)
-                update_learners_progress_for_course(course)
+                update_learners_progress_for_course.delay(str(course.id))
             except Exception as e:  # pylint: disable=broad-except
                 logger.exception('figures.tasks.populate_daily_metrics failed')
                 # Always capture CDM load exceptions to the Figures pipeline

--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -9,22 +9,16 @@ import time
 from celery import chord
 from celery.app import shared_task
 from celery.utils.log import get_task_logger
-from completion.models import BlockCompletion
 from django.contrib.sites.models import Site
 from datetime import timezone
+from edly_features_app.tasks import update_student_course_progress_for_course
 from edly_features_app.utils import get_active_tenant_lms_sites
 import six
 from edx_django_utils.db.read_replica import read_replica_or_default
 
-from edly_panel_app.api.v1.helpers import get_block_types_and_keys
-from lms.djangoapps.course_api.blocks.transformers.blocks_api import BlocksAPITransformer
-from openedx.core.djangoapps.content.block_structure.api import get_course_in_cache
-from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers
-# from openedx.features.edly.models import EdlySubOrganization, StudentCourseProgress
-
 from figures.backfill import backfill_enrollment_data_for_site
 from figures.compat import CourseEnrollment, CourseOverview
-from figures.helpers import as_course_key, as_date, get_course_block_name
+from figures.helpers import as_course_key, as_date
 from figures.log import log_exec_time
 from figures.models import PipelineError
 from figures.helpers import as_course_key, as_date, is_past_date, is_multisite
@@ -119,61 +113,13 @@ def update_enrollment_data(site_id, **_kwargs):
 @shared_task
 def update_learners_progress_for_course(course):
     """
-    This updates all learners' progress for the course.
+    Recompute ``StudentCourseProgress`` rows for every active enrollment
+    in the given course.
+
+    Delegates to ``edly_features_app.tasks.update_student_course_progress_for_course``
+    where the SCP model and traversal logic live.
     """
-    course_enrollments = CourseEnrollment.objects.filter(course=course)
-    course_structure = get_course_in_cache(course._location.course_key)
-    complete_course_structure = course_structure.copy()
-    block_types, course_block_keys = get_block_types_and_keys(course_structure)
-    transformers = BlockStructureTransformers()
-    transformers += [
-        BlocksAPITransformer(
-            block_types_to_count=block_types,
-            requested_student_view_data=set([]),
-            depth=0,
-        )
-    ]
-
-    transformers.transform(course_structure)
-
-    for enrollment in course_enrollments:
-        completions = BlockCompletion.objects.filter(
-            user=enrollment.user,
-            context_key=enrollment.course_id,
-            block_key__in=course_block_keys,
-        )
-
-        if not completions:
-            continue
-
-        farthest_completed_block = None
-        completion_block_ids = [completion.block_key.block_id for completion in completions]
-        for course_block_key in complete_course_structure.topological_traversal():
-            if course_block_key.block_id in completion_block_ids:
-                farthest_completed_block = course_block_key
-
-        if not farthest_completed_block:
-            continue
-
-        completion_date = None
-        for completion in completions:
-            if completion.block_key.block_id == farthest_completed_block.block_id:
-                completion_date = completion.created
-
-        unit = complete_course_structure.get_parents(farthest_completed_block)[0]
-        subsection = complete_course_structure.get_parents(unit)[0]
-        section = complete_course_structure.get_parents(subsection)[0]
-        StudentCourseProgress.objects.update_or_create(
-            student=enrollment.user,
-            course_id=course._location.course_key,
-            defaults=dict(
-                completed_block=get_course_block_name(complete_course_structure, farthest_completed_block),
-                completed_unit=get_course_block_name(complete_course_structure, unit),
-                completed_subsection=get_course_block_name(complete_course_structure, subsection),
-                completed_section=get_course_block_name(complete_course_structure, section),
-                completion_date=completion_date,
-            )
-        )
+    update_student_course_progress_for_course(str(course.id))
 
 
 @shared_task


### PR DESCRIPTION
## Description

[Edly-8214](https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-8214/)

CSV report emails (learner report, advance course data, insights-learner) were silently failing on ulmo. The root cause was a commented-out import of `StudentCourseProgress` from `openedx.features.edly.models` — a Juniper-era module that no longer exists. The lms-worker raised a NameError on every report task, and no email was delivered. `StudentCourseProgress` is now restored in `edly_features_app` (see companion PR in edly-features-app). Originally introduced in [edly-io/edx-platform#334](https://github.com/edly-io/edx-platform/pull/334) & [edly-io/figures#94](https://github.com/edly-io/figures/pull/94).

## What changed
- Import `StudentCourseProgress` from `edly_features_app.models`.
- Normalize the `course_id` query param in `_prepare_advance_course_data` via `CourseKey.from_string(course_id.replace(' ', '+'))` — URL decoding converts `+` to spaces, which broke the `CourseKeyField` filter.
- Return `['N/A', 'N/A', 'N/A', 'N/A', 'N/A']` instead of `[]` from `get_farthest_complete_course_block` when no SCP row exists — the empty list was causing column misalignment in generated CSV rows.
- Pass `context['site'] = site_obj` in `_prepare_learners_data` so the insights-learner serializer can resolve `last_course_activity_date` correctly; without it the field was always N/A.
- Delegate `update_learners_progress_for_course` in `figures/tasks.py` entirely to `edly_features_app.tasks.update_student_course_progress_for_course` — removes dead bulk-completion traversal code that had been inlined here.

## Improvements over the original
- No dead import guards or commented-out model references — clean import from the plugin app.
- Column alignment and N/A fallback are explicit, preventing silent data corruption in CSV output.
- Progress population logic is fully decoupled from figures — figures only reads SCP, edly_features_app owns writing it.
